### PR TITLE
broken-link-fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The detailed documentation for contributing content pieces is available at [Cont
 
 ## For DevLake Dashboard
 
-The detailed documentation for creating DevLake dashboard is available at [Dashboard/README.md](Dashboard/README.md).
+The detailed documentation for creating DevLake dashboard is available at [Dashboard/README.md](https://devlake.apache.org/docs/UserManuals/Dashboards/GrafanaUserGuide).
 
 ## Checklist
 


### PR DESCRIPTION
The link was not working and was set to a folder that does not contain the guide. I have changed its link to the guide available on the devlake web
Signed-off-by: Basit Hasan <hasanbasit13@gmail.com>